### PR TITLE
add setVelocity method and explanation for ESP32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ The original library is designed for Arduino board, using `analogWrite`, which m
 Using [ESP32_AnalogWrite](https://github.com/erropix/ESP32_AnalogWrite) or [AnalogWrite_ESP32](https://github.com/pablomarquez76/AnalogWrite_ESP32) can overwrite `ledcWrite` of ESP32 to `analogWrite`.
 As [pablomarquez76](https://github.com/pablomarquez76/AnalogWrite_ESP32/issues/6) saind, ESP32 has supported `analogWrite` after 2.0.11. The official document is [at here](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html?highlight=analogWrite#analogwrite).The resolution is form 0 to 255, testing normal. So nothing needs change.
 
+I added a method to get input from -255 to 255 to control the motor. It is for easier direction control.
+
+I tested it with PID library. Sometimes PID always output 0. Sometimes it works. I didn't find the reason. It might because ESP32Encoder or this repo use the same timer with PID. I am not sure. Be careful.
+
 The below is original readme.
 
 # L298N Library

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# Explanation
+
+The library is forked from [L298n](https://github.com/AndreaLombardo/L298N).
+The original library is designed for Arduino board, using `analogWrite`, which may cause some problem on ESP32.
+Using [ESP32_AnalogWrite](https://github.com/erropix/ESP32_AnalogWrite) or [AnalogWrite_ESP32](https://github.com/pablomarquez76/AnalogWrite_ESP32) can overwrite `ledcWrite` of ESP32 to `analogWrite`.
+As [pablomarquez76](https://github.com/pablomarquez76/AnalogWrite_ESP32/issues/6) saind, ESP32 has supported `analogWrite` after 2.0.11. The official document is [at here](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html?highlight=analogWrite#analogwrite).The resolution is form 0 to 255, testing normal. So nothing needs change.
+
+I added a method to get input from -255 to 255 to control the motor. It is for easier direction control.
+
+I tested it with PID library. Sometimes PID always output 0. Sometimes it works. I didn't find the reason. It might because ESP32Encoder or this repo use the same timer with PID. I am not sure. Be careful.
+
+The below is original readme.
+
 # L298N Library
 
 An easy to use L298N library to control DC Motors with Arduino.
@@ -14,12 +27,6 @@ but it stands for a double implementation of L298N library.
 ## INSTALL THE LIBRARY
 
 Download this repository as a .zip file and from the Arduino IDE go to _Sketch -> Include library -> Add .ZIP Library_
-
-## ESP32 Support
-
-The original library is for Arduino board, using `analogWrite`, which may cause some problem on ESP32.  
-Using [ESP32_AnalogWrite](https://github.com/erropix/ESP32_AnalogWrite) or [AnalogWrite_ESP32](https://github.com/pablomarquez76/AnalogWrite_ESP32) can overwrite `ledcWrite` of ESP32 to `analogWrite`.
-As [pablomarquez76](https://github.com/pablomarquez76/AnalogWrite_ESP32/issues/6) saind, ESP32 has supported `analogWrite` after 2.0.11. The official document is [at here](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html?highlight=analogWrite#analogwrite).The resolution is form 0 to 255, testing normal. So nothing needs to be changed and it works well on ESP32.
 
 ## IMPORT
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-# Explanation
-
-The library is forked from [L298n](https://github.com/AndreaLombardo/L298N).
-The original library is designed for Arduino board, using `analogWrite`, which may cause some problem on ESP32.
-Using [ESP32_AnalogWrite](https://github.com/erropix/ESP32_AnalogWrite) or [AnalogWrite_ESP32](https://github.com/pablomarquez76/AnalogWrite_ESP32) can overwrite `ledcWrite` of ESP32 to `analogWrite`.
-As [pablomarquez76](https://github.com/pablomarquez76/AnalogWrite_ESP32/issues/6) saind, ESP32 has supported `analogWrite` after 2.0.11. The official document is [at here](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html?highlight=analogWrite#analogwrite).The resolution is form 0 to 255, testing normal. So nothing needs change.
-
-I added a method to get input from -255 to 255 to control the motor. It is for easier direction control.
-
-I tested it with PID library. Sometimes PID always output 0. Sometimes it works. I didn't find the reason. It might because ESP32Encoder or this repo use the same timer with PID. I am not sure. Be careful.
-
-The below is original readme.
-
 # L298N Library
 
 An easy to use L298N library to control DC Motors with Arduino.
@@ -27,6 +14,12 @@ but it stands for a double implementation of L298N library.
 ## INSTALL THE LIBRARY
 
 Download this repository as a .zip file and from the Arduino IDE go to _Sketch -> Include library -> Add .ZIP Library_
+
+## ESP32 Support
+
+The original library is for Arduino board, using `analogWrite`, which may cause some problem on ESP32.  
+Using [ESP32_AnalogWrite](https://github.com/erropix/ESP32_AnalogWrite) or [AnalogWrite_ESP32](https://github.com/pablomarquez76/AnalogWrite_ESP32) can overwrite `ledcWrite` of ESP32 to `analogWrite`.
+As [pablomarquez76](https://github.com/pablomarquez76/AnalogWrite_ESP32/issues/6) saind, ESP32 has supported `analogWrite` after 2.0.11. The official document is [at here](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html?highlight=analogWrite#analogwrite).The resolution is form 0 to 255, testing normal. So nothing needs to be changed and it works well on ESP32.
 
 ## IMPORT
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Explanation
+
+The library is forked from [L298n](https://github.com/AndreaLombardo/L298N).
+The original library is designed for Arduino board, using `analogWrite`, which may cause some problem on ESP32.
+Using [ESP32_AnalogWrite](https://github.com/erropix/ESP32_AnalogWrite) or [AnalogWrite_ESP32](https://github.com/pablomarquez76/AnalogWrite_ESP32) can overwrite `ledcWrite` of ESP32 to `analogWrite`.
+As [pablomarquez76](https://github.com/pablomarquez76/AnalogWrite_ESP32/issues/6) saind, ESP32 has supported `analogWrite` after 2.0.11. The official document is [at here](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html?highlight=analogWrite#analogwrite).The resolution is form 0 to 255, testing normal. So nothing needs change.
+
+The below is original readme.
+
 # L298N Library
 
 An easy to use L298N library to control DC Motors with Arduino.

--- a/src/L298N.cpp
+++ b/src/L298N.cpp
@@ -143,7 +143,16 @@ void L298N::reset() {
   _canMove = true;
 }
 
+// the velocity is a number between -255 and 255
+// positive values are for forward movements
+// negative values are for backward movements
 void L298N::setVelocity(int velocity){
+  if (velocity > 255) {
+    velocity = 255;
+  } else if (velocity < -255) {
+    velocity = -255;
+  }
+
   if (velocity > 0) {
     this->setSpeed((unsigned short)velocity);
     this->forward();
@@ -155,6 +164,9 @@ void L298N::setVelocity(int velocity){
   }
 }
 
+// the acceleration can be positive or negative
+// negative values does not mean deceleration
+// it means the direction of the acceleration is negative
 void L298N::accelerate(int acceleration) {
   int velocity = this->getSpeed();
   if (_direction = BACKWARD) {

--- a/src/L298N.cpp
+++ b/src/L298N.cpp
@@ -153,7 +153,6 @@ void L298N::setVelocity(int velocity){
   } else {
     this->stop();
   }
-
 }
 
 void L298N::accelerate(int acceleration) {

--- a/src/L298N.cpp
+++ b/src/L298N.cpp
@@ -169,7 +169,7 @@ void L298N::setVelocity(int velocity){
 // it means the direction of the acceleration is negative
 void L298N::accelerate(int acceleration) {
   int velocity = this->getSpeed();
-  if (_direction = BACKWARD) {
+  if (_direction == BACKWARD) {
     velocity = -velocity;
   }
   velocity += acceleration;

--- a/src/L298N.cpp
+++ b/src/L298N.cpp
@@ -143,6 +143,19 @@ void L298N::reset() {
   _canMove = true;
 }
 
+void L298N::control(int speed){
+  if (speed > 0) {
+    this->setSpeed(speed);
+    this->forward();
+  } else if (speed < 0) {
+    this->setSpeed(-speed);
+    this->backward();
+  } else {
+    this->stop();
+  }
+
+}
+
 boolean L298N::isMoving() {
   return _isMoving;
 }

--- a/src/L298N.cpp
+++ b/src/L298N.cpp
@@ -143,17 +143,31 @@ void L298N::reset() {
   _canMove = true;
 }
 
-void L298N::control(int speed){
-  if (speed > 0) {
-    this->setSpeed(speed);
+void L298N::setVelocity(int velocity){
+  if (velocity > 0) {
+    this->setSpeed((unsigned short)velocity);
     this->forward();
-  } else if (speed < 0) {
-    this->setSpeed(-speed);
+  } else if (velocity < 0) {
+    this->setSpeed((unsigned short)(-velocity));
     this->backward();
   } else {
     this->stop();
   }
 
+}
+
+void L298N::accelerate(int acceleration) {
+  int velocity = this->getSpeed();
+  if (_direction = BACKWARD) {
+    velocity = -velocity;
+  }
+  velocity += acceleration;
+  if (velocity > 255) {
+    velocity = 255;
+  } else if (velocity < -255) {
+    velocity = -255;
+  }
+  this->setVelocity(velocity);
 }
 
 boolean L298N::isMoving() {

--- a/src/L298N.h
+++ b/src/L298N.h
@@ -30,7 +30,8 @@ public:
    void runFor(unsigned long delay, L298N::Direction direction, CallBackFunction callback);
    void stop();
    void reset();
-   void control(int speed);
+   void setVelocity(int velocity);
+   void accelerate(int acceleration);
    boolean isMoving();
    Direction getDirection();
 

--- a/src/L298N.h
+++ b/src/L298N.h
@@ -30,6 +30,7 @@ public:
    void runFor(unsigned long delay, L298N::Direction direction, CallBackFunction callback);
    void stop();
    void reset();
+   void control(int speed);
    boolean isMoving();
    Direction getDirection();
 


### PR DESCRIPTION
I added a method to get input from -255 to 255 to control the motor velocity, including forward and backward. It is for easier direction control. It is useful when using PID control (the PID output can directly input to this library now). 

I tested the library on ESP32 and it works for the new version. After ESP32 2.0.11, it supports `analogWrite` so it works well. 
